### PR TITLE
chore: ignore .developer folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ ios/generated
 android/generated
 
 example/ios/.xcode.env.local
+
+# Upwork related
+.developer/


### PR DESCRIPTION
Add folder for storing test scripts, keys and other assets from communication with client and ignore it