### PR TITLE
ci: fix build-ios step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Build example for Android
         env:
-          JAVA_OPTS: "-XX:MaxHeapSize=6g"
+          JAVA_OPTS: '-XX:MaxHeapSize=6g'
         run: |
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
@@ -146,9 +146,7 @@ jobs:
 
       - name: Install cocoapods
         if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
-        run: |
-          cd example/ios
-          pod install
+        run: yarn example:ios:pod
         env:
           NO_FLIPPER: 1
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1246,7 +1246,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-amazon-ivs-stages (0.0.3):
+  - react-native-amazon-ivs-stages (0.0.4):
     - AmazonIVSBroadcast/Stages (~> 1.24.0)
     - AmazonIVSChat (~> 1.0.0)
     - DoubleConversion
@@ -1782,7 +1782,7 @@ SPEC CHECKSUMS:
   React-logger: 09934f68c9c8bf4b427addd641f4cae341564d61
   React-Mapbuffer: 6385e4446caaaa433decaa94f398ad3f593cfc05
   React-microtasksnativemodule: e5e9a87d630359490359f7143215987254af65a8
-  react-native-amazon-ivs-stages: 0b89bcf164cb6295be106d996729ff7f172a48b2
+  react-native-amazon-ivs-stages: 2d7cf0d84c9d4e6beb6c12bca3e3ee99c78b3745
   React-nativeconfig: 2199ff468fce8b95d1776d9cea31d35076fe7e48
   React-NativeModulesApple: 3fd0069e45be0a560ed52f57ce8d8c42898f69b8
   React-perflogger: ab4e872853e59282b94df46f17c84d83290579e4


### PR DESCRIPTION
### 📯 &nbsp; Description

Fix ios build in GH actions. Check issue [here](https://github.com/facebook/react-native/issues/34651)

### 📝 &nbsp; Summary of Changes

- Regenerate the `Podfile.lock` for the example; cache for turbo relies on it
- Update the `pod install` command of the ios build GH action

### 🧪 &nbsp; How Has This Been Tested?

Please describe the tests that you ran to verify your changes and note any relevant details for your test configuration.

- [ ] iOS builds and runs
- [ ] Android builds and runs

#### 🧰 &nbsp; Links & Resources

- [Some Link](LINK_HERE)

#### 📸 &nbsp; Screenshots

| Before      | After     |
| ----------- | --------- |
| :neckbeard: | :octocat: |

#### ✅ &nbsp; Author checklist

Required:

- [x] I have performed a self-review of my own code
